### PR TITLE
Backend/select competitive stat

### DIFF
--- a/api/src/controllers/plant.go
+++ b/api/src/controllers/plant.go
@@ -166,22 +166,23 @@ func computerChooseCompetitiveStat(opponentPlant *models.Plant) string {
 	// Step 0:  We're going to be using random choice twice in this function so we set it up here
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	// Step 1: Determine if plant is edible, if the plant is edible there is a random chance this will be the return value
-	if opponentPlant.Edible {
-		if r.Intn(10) % 2 == 0 {
-			return "edible"
-		}
+	if r.Intn(10) % 2 == 0 && opponentPlant.Edible  {
+			return "edible"	
 	}
 	// Step 2: Compare light, soil nutriments and atmospheric humidity to determine which is the lowest and therefore most competitive 
 	lowestCompValueName := bestLow(opponentPlant)
+	fmt.Println("Here is lowestCompValueName: ", lowestCompValueName)
 	fieldName := convertSnakeToPascal(lowestCompValueName)
+	fmt.Println("Here is fieldName: ", fieldName)
 	lowestCompValue :=reflect.ValueOf(*opponentPlant).FieldByName(fieldName)
+	fmt.Println("Here is lowestCompValue: ", lowestCompValue)
 
 	// Step 3: Determine if the ph range is high enough to be competitive, if not the most competitive value from step 2 takes precedence
 	phRange := opponentPlant.CalculatePhRange()
 
 	if phRange > 25 && lowestCompValue.Int() >= 5 {
 		return "ph_range"
-	} else if lowestCompValueName != "null" {
+	} else if lowestCompValueName != "null" && lowestCompValue.Int() <= 5 {
 		return lowestCompValueName
 	}
 	// Step 4: Check if year is competitive, there is a random chance of it's being returned if so, otherwise return either ph range, light, soil nutriments or atmospheric humidity, depending on what was found the most competitive value 
@@ -201,28 +202,29 @@ func computerChooseCompetitiveStat(opponentPlant *models.Plant) string {
 	return randomValue
 }
 
+// This function checks the three card fields that win by being lower than their opponent
+// It will return a string referring to the lowest (and therefore most competitive) value
 func bestLow(opponent_card *models.Plant) string {
+	// Step 1: Define the name of the varibale we want to return
 	var lowest string 
-	if opponent_card.Light < opponent_card.SoilNutriments && opponent_card.Light < opponent_card.AtmosphericHumidity {     
-		// checks if light is lowest value                  
-		lowest = "light"	
 
-	} else if opponent_card.SoilNutriments < opponent_card.Light && opponent_card.SoilNutriments < opponent_card.AtmosphericHumidity{ 
-		// checks if soil nutirments is lowest value       
-		lowest = "soil_nutriments"
+	// Step 2: Create a map containing the three values we want to check
+	checkValues := make(map[string]int)
 
-	} else if opponent_card.AtmosphericHumidity < opponent_card.SoilNutriments && opponent_card.AtmosphericHumidity < opponent_card.Light{   
-		// checks if atmospheric humidity is lowest value
-		lowest = "atmospheric_humidity"
-
-	} else if opponent_card.Light == opponent_card.SoilNutriments && opponent_card.Light == opponent_card.AtmosphericHumidity {
-		// Checks if all fields are equal, returns one randomly if they are all equal and lower than four
-		fields := [3]string{"light", "soil_nutriments", "atmospheric_humidity"} 
-		rand.Shuffle((3), func(i, j int) {
-			fields[i], fields[j] = fields[j], fields[i]
-		})
-		lowest = fields[0]   
-	}
+	checkValues["light"] = opponent_card.Light
+	checkValues["soil_nutriments"] = opponent_card.SoilNutriments
+	checkValues["atmospheric_humidity"] = opponent_card.AtmosphericHumidity
+	
+	// Step 3: Loop through the map to find the lowest value
+	// This method allows for situations in which all values are equal or 
+	// the two lowest values being the same
+	for key, val := range checkValues {
+		if lowest == "" {
+			lowest = key
+		} else if val < checkValues[lowest]{
+			lowest = key
+		}
+	}  
 
 	return lowest
 }

--- a/api/src/controllers/plant.go
+++ b/api/src/controllers/plant.go
@@ -170,20 +170,16 @@ func computerChooseCompetitiveStat(opponentPlant *models.Plant) string {
 			return "edible"	
 	}
 	// Step 2: Compare light, soil nutriments and atmospheric humidity to determine which is the lowest and therefore most competitive 
-	lowestCompValueName := bestLow(opponentPlant)
-	fmt.Println("Here is lowestCompValueName: ", lowestCompValueName)
-	fieldName := convertSnakeToPascal(lowestCompValueName)
-	fmt.Println("Here is fieldName: ", fieldName)
-	lowestCompValue :=reflect.ValueOf(*opponentPlant).FieldByName(fieldName)
-	fmt.Println("Here is lowestCompValue: ", lowestCompValue)
+	fieldName, value := bestLow(opponentPlant)
+	
 
 	// Step 3: Determine if the ph range is high enough to be competitive, if not the most competitive value from step 2 takes precedence
 	phRange := opponentPlant.CalculatePhRange()
 
-	if phRange > 25 && lowestCompValue.Int() >= 5 {
+	if phRange > 25 && value >= 5 {
 		return "ph_range"
-	} else if lowestCompValueName != "null" && lowestCompValue.Int() <= 5 {
-		return lowestCompValueName
+	} else if fieldName != "null" && value <= 5 {
+		return fieldName
 	}
 	// Step 4: Check if year is competitive, there is a random chance of it's being returned if so, otherwise return either ph range, light, soil nutriments or atmospheric humidity, depending on what was found the most competitive value 
 	if opponentPlant.Year <= 1753 {
@@ -204,9 +200,10 @@ func computerChooseCompetitiveStat(opponentPlant *models.Plant) string {
 
 // This function checks the three card fields that win by being lower than their opponent
 // It will return a string referring to the lowest (and therefore most competitive) value
-func bestLow(opponent_card *models.Plant) string {
+func bestLow(opponent_card *models.Plant) (string, int) {
 	// Step 1: Define the name of the varibale we want to return
-	var lowest string 
+	var lowestFieldName string 
+	var fieldValue int
 
 	// Step 2: Create a map containing the three values we want to check
 	checkValues := make(map[string]int)
@@ -219,14 +216,16 @@ func bestLow(opponent_card *models.Plant) string {
 	// This method allows for situations in which all values are equal or 
 	// the two lowest values being the same
 	for key, val := range checkValues {
-		if lowest == "" {
-			lowest = key
-		} else if val < checkValues[lowest]{
-			lowest = key
+		if lowestFieldName == "" {
+			lowestFieldName = key
+			fieldValue = val
+		} else if val < checkValues[lowestFieldName]{
+			lowestFieldName = key
+			fieldValue = val
 		}
 	}  
 
-	return lowest
+	return lowestFieldName, fieldValue
 }
 
 func convertSnakeToPascal(statToCompare string) string {

--- a/api/src/controllers/plant.go
+++ b/api/src/controllers/plant.go
@@ -99,11 +99,17 @@ func ComparePlants(c *gin.Context) {
 	}
 	statToCompare := requestBody.StatToCompare
 
-	// Step 2: Grabbing those plants from the DB
+	// Step 3: Checking if it is the user or computer's turn 
+	if statToCompare == "null" {
+		c.JSON(http.StatusOK, gin.H{"turn": "it's the computer's turn!"})
+		return
+	}
+
+	// Step 4: Grabbing those plants from the DB
 	playerPlant, _ := models.FetchPlantById(requestBody.PlayerCard)
 	opponentPlant, _ := models.FetchPlantById(requestBody.OpponentCard)
 
-	// Step 3: Calculate who wins (or draws) using the helper function
+	// Step 5: Calculate who wins (or draws) using the helper function
 	winner := DeterminePlantWinner(playerPlant, opponentPlant, statToCompare)
 
 	if winner == "" {

--- a/api/src/controllers/plant.go
+++ b/api/src/controllers/plant.go
@@ -88,7 +88,7 @@ func GetAllPlants(c *gin.Context) {
 type ComparisonSruct struct {
 	PlayerCard    uint   `json:"player_card"`
 	OpponentCard  uint   `json:"opponent_card"`
-	StatToCompare string `json:"stat_to_compare"`
+	StatToCompare *string `json:"stat_to_compare"`
 }
 
 // --------------- Compare player and opponent plants based on stat to compare and return the winner ----------------//
@@ -109,16 +109,18 @@ func ComparePlants(c *gin.Context) {
 	opponentPlant, _ := models.FetchPlantById(requestBody.OpponentCard)
 	
 	// Step 3: Checking if it is the user or computer's turn 
-	if statToCompare == "null" {
-		statToCompare = computerChooseCompetitiveStat(opponentPlant)
+	
+	if statToCompare == nil {
+		computerChoice := computerChooseCompetitiveStat(opponentPlant)
+		statToCompare = &computerChoice
 	}
 
 	// Step 4: Calculate who wins (or draws) using the helper function
-	winner := DeterminePlantWinner(playerPlant, opponentPlant, statToCompare)
+	winner := DeterminePlantWinner(playerPlant, opponentPlant, *statToCompare)
 
 	if winner == "" {
 		c.JSON(http.StatusBadRequest, gin.H{
-			"error":       fmt.Sprintf("Invalid stat to compare: %s", statToCompare),
+			"error":       fmt.Sprintf("Invalid stat to compare: %s", *statToCompare),
 			"valid_stats": []string{"year", "light", "soil_nutriments", "atmospheric_humidity", "edible", "ph_range"},
 		})
 		return

--- a/api/src/controllers/plant.go
+++ b/api/src/controllers/plant.go
@@ -39,6 +39,8 @@ type PhLevels struct {
 	PhAverage float64 `json:"ph_average"`
 }
 
+// --------------- Fetch all plants from DB, shuffle them and return twenty random cards ----------------//
+
 func GetAllPlants(c *gin.Context) {
 	// Fetch all plants from the database
 	plants, err := models.FetchAllPlants()
@@ -89,6 +91,8 @@ type ComparisonSruct struct {
 	StatToCompare string `json:"stat_to_compare"`
 }
 
+// --------------- Compare player and opponent plants based on stat to compare and return the winner ----------------//
+
 func ComparePlants(c *gin.Context) {
 	// Step 1: Grabbing plant IDs & stat to compare
 	var requestBody ComparisonSruct
@@ -109,8 +113,6 @@ func ComparePlants(c *gin.Context) {
 		statToCompare = computerChooseCompetitiveStat(opponentPlant)
 	}
 
-	
-
 	// Step 4: Calculate who wins (or draws) using the helper function
 	winner := DeterminePlantWinner(playerPlant, opponentPlant, statToCompare)
 
@@ -124,6 +126,8 @@ func ComparePlants(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{"winner": winner, "stat": statToCompare})
 }
+
+// --------------- Compares two plants based on statToCompare and returns a string saying who has won ----------------//
 
 func DeterminePlantWinner(playerPlant, opponentPlant *models.Plant, statToCompare string) string {
 	if statToCompare == "edible" {
@@ -162,31 +166,35 @@ func DeterminePlantWinner(playerPlant, opponentPlant *models.Plant, statToCompar
 	}
 }
 
+// --------------- Choose a competitive stat to play if it is the computer's turn ----------------//
+
 func computerChooseCompetitiveStat(opponentPlant *models.Plant) string {
-	// Step 0:  We're going to be using random choice twice in this function so we set it up here
+	// Step 0: Create new rand to be used throughout function
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	// Step 1: Determine if plant is edible, if the plant is edible there is a random chance this will be the return value
 	if r.Intn(10) % 2 == 0 && opponentPlant.Edible  {
 			return "edible"	
 	}
-	// Step 2: Compare light, soil nutriments and atmospheric humidity to determine which is the lowest and therefore most competitive 
-	fieldName, value := bestLow(opponentPlant)
-	
 
-	// Step 3: Determine if the ph range is high enough to be competitive, if not the most competitive value from step 2 takes precedence
+	// Step 2: Compare light, soil nutriments and atmospheric humidity to determine which has the lowest score 
+	fieldName, score := findLowestScore(opponentPlant)
+	
+	// Step 3: Calculate ph range, compare ph range to the result of findLowestScore to see which is the most competitive
 	phRange := opponentPlant.CalculatePhRange()
 
-	if phRange > 25 && value >= 5 {
+	if phRange > 25 && score >= 5 {
 		return "ph_range"
-	} else if fieldName != "null" && value <= 5 {
+	} else if fieldName != "null" && score <= 5 {
 		return fieldName
 	}
-	// Step 4: Check if year is competitive, there is a random chance of it's being returned if so, otherwise return either ph range, light, soil nutriments or atmospheric humidity, depending on what was found the most competitive value 
+
+	// Step 4: Check if the value of year is competitive
 	if opponentPlant.Year <= 1753 {
 		return "year"
 	}
 
-	// Step 5: If all the comaprisons fail then we just give up and pick something at random
+	// Step 5: If all the comparisons fail a stat is returned at random
 	var randomValue string
 	possiblevalues := [6]string{"year", "edible", "light", "nutriments_required", "humidity_level", "ph_range"}
 	rand.Shuffle((3), func(i, j int) {
@@ -198,10 +206,11 @@ func computerChooseCompetitiveStat(opponentPlant *models.Plant) string {
 	return randomValue
 }
 
-// This function checks the three card fields that win by being lower than their opponent
-// It will return a string referring to the lowest (and therefore most competitive) value
-func bestLow(opponent_card *models.Plant) (string, int) {
-	// Step 1: Define the name of the varibale we want to return
+
+// --------------- Find the value with the lowest score, returns the name and score of lowest value ----------------//
+
+func findLowestScore(opponent_card *models.Plant) (string, int) {
+	// Step 1: Define the name of the variables we want to return
 	var lowestFieldName string 
 	var fieldValue int
 
@@ -212,9 +221,7 @@ func bestLow(opponent_card *models.Plant) (string, int) {
 	checkValues["soil_nutriments"] = opponent_card.SoilNutriments
 	checkValues["atmospheric_humidity"] = opponent_card.AtmosphericHumidity
 	
-	// Step 3: Loop through the map to find the lowest value
-	// This method allows for situations in which all values are equal or 
-	// the two lowest values being the same
+	// Step 3: Loop through the map to find value with lowest score
 	for key, val := range checkValues {
 		if lowestFieldName == "" {
 			lowestFieldName = key
@@ -224,9 +231,11 @@ func bestLow(opponent_card *models.Plant) (string, int) {
 			fieldValue = val
 		}
 	}  
-
+	
 	return lowestFieldName, fieldValue
 }
+
+// -- Converts snake case strings taken from JSON data into a format that can be used to index struct values using the reflect package ----------------//
 
 func convertSnakeToPascal(statToCompare string) string {
 		// Convert snake_case (json) to PascalCase (needed for struct field access)

--- a/api/src/controllers/plant.go
+++ b/api/src/controllers/plant.go
@@ -99,17 +99,19 @@ func ComparePlants(c *gin.Context) {
 	}
 	statToCompare := requestBody.StatToCompare
 
-	// Step 3: Checking if it is the user or computer's turn 
-	if statToCompare == "null" {
-		c.JSON(http.StatusOK, gin.H{"turn": "it's the computer's turn!"})
-		return
-	}
-
-	// Step 4: Grabbing those plants from the DB
+	
+	// Step 2: Grabbing those plants from the DB
 	playerPlant, _ := models.FetchPlantById(requestBody.PlayerCard)
 	opponentPlant, _ := models.FetchPlantById(requestBody.OpponentCard)
+	
+	// Step 3: Checking if it is the user or computer's turn 
+	if statToCompare == "null" {
+		statToCompare = computerChooseCompetitiveStat(opponentPlant)
+	}
 
-	// Step 5: Calculate who wins (or draws) using the helper function
+	
+
+	// Step 4: Calculate who wins (or draws) using the helper function
 	winner := DeterminePlantWinner(playerPlant, opponentPlant, statToCompare)
 
 	if winner == "" {
@@ -120,7 +122,7 @@ func ComparePlants(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"winner": winner})
+	c.JSON(http.StatusOK, gin.H{"winner": winner, "stat": statToCompare})
 }
 
 func DeterminePlantWinner(playerPlant, opponentPlant *models.Plant, statToCompare string) string {
@@ -145,6 +147,88 @@ func DeterminePlantWinner(playerPlant, opponentPlant *models.Plant, statToCompar
 		}
 	} else {
 		// Convert snake_case (json) to PascalCase (needed for struct field access)
+		fieldName := convertSnakeToPascal(statToCompare)
+
+		playerValue := reflect.ValueOf(*playerPlant).FieldByName(fieldName)
+		opponentValue := reflect.ValueOf(*opponentPlant).FieldByName(fieldName)
+
+		if playerValue.Int() < opponentValue.Int() {
+			return "player"
+		} else if opponentValue.Int() < playerValue.Int() {
+			return "opponent"
+		} else {
+			return "draw"
+		}
+	}
+}
+
+func computerChooseCompetitiveStat(opponentPlant *models.Plant) string {
+	// Step 0:  We're going to be using random choice twice in this function so we set it up here
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	// Step 1: Determine if plant is edible, if the plant is edible there is a random chance this will be the return value
+	if opponentPlant.Edible {
+		if r.Intn(10) % 2 == 0 {
+			return "edible"
+		}
+	}
+	// Step 2: Compare light, soil nutriments and atmospheric humidity to determine which is the lowest and therefore most competitive 
+	lowestCompValueName := bestLow(opponentPlant)
+	fieldName := convertSnakeToPascal(lowestCompValueName)
+	lowestCompValue :=reflect.ValueOf(*opponentPlant).FieldByName(fieldName)
+
+	// Step 3: Determine if the ph range is high enough to be competitive, if not the most competitive value from step 2 takes precedence
+	phRange := opponentPlant.CalculatePhRange()
+
+	if phRange > 25 && lowestCompValue.Int() >= 5 {
+		return "ph_range"
+	} else if lowestCompValueName != "null" {
+		return lowestCompValueName
+	}
+	// Step 4: Check if year is competitive, there is a random chance of it's being returned if so, otherwise return either ph range, light, soil nutriments or atmospheric humidity, depending on what was found the most competitive value 
+	if opponentPlant.Year <= 1753 {
+		return "year"
+	}
+
+	// Step 5: If all the comaprisons fail then we just give up and pick something at random
+	var randomValue string
+	possiblevalues := [6]string{"year", "edible", "light", "nutriments_required", "humidity_level", "ph_range"}
+	rand.Shuffle((3), func(i, j int) {
+		possiblevalues[i], possiblevalues[j] = possiblevalues[j], possiblevalues[i]
+	})
+
+	randomValue = possiblevalues[0]
+
+	return randomValue
+}
+
+func bestLow(opponent_card *models.Plant) string {
+	var lowest string 
+	if opponent_card.Light < opponent_card.SoilNutriments && opponent_card.Light < opponent_card.AtmosphericHumidity {     
+		// checks if light is lowest value                  
+		lowest = "light"	
+
+	} else if opponent_card.SoilNutriments < opponent_card.Light && opponent_card.SoilNutriments < opponent_card.AtmosphericHumidity{ 
+		// checks if soil nutirments is lowest value       
+		lowest = "soil_nutriments"
+
+	} else if opponent_card.AtmosphericHumidity < opponent_card.SoilNutriments && opponent_card.AtmosphericHumidity < opponent_card.Light{   
+		// checks if atmospheric humidity is lowest value
+		lowest = "atmospheric_humidity"
+
+	} else if opponent_card.Light == opponent_card.SoilNutriments && opponent_card.Light == opponent_card.AtmosphericHumidity {
+		// Checks if all fields are equal, returns one randomly if they are all equal and lower than four
+		fields := [3]string{"light", "soil_nutriments", "atmospheric_humidity"} 
+		rand.Shuffle((3), func(i, j int) {
+			fields[i], fields[j] = fields[j], fields[i]
+		})
+		lowest = fields[0]   
+	}
+
+	return lowest
+}
+
+func convertSnakeToPascal(statToCompare string) string {
+		// Convert snake_case (json) to PascalCase (needed for struct field access)
 		fieldMap := map[string]string{
 			"year":                 "Year",
 			"light":                "Light",
@@ -160,15 +244,5 @@ func DeterminePlantWinner(playerPlant, opponentPlant *models.Plant, statToCompar
 			return "" // Invalid stat
 		}
 
-		playerValue := reflect.ValueOf(*playerPlant).FieldByName(fieldName)
-		opponentValue := reflect.ValueOf(*opponentPlant).FieldByName(fieldName)
-
-		if playerValue.Int() < opponentValue.Int() {
-			return "player"
-		} else if opponentValue.Int() < playerValue.Int() {
-			return "opponent"
-		} else {
-			return "draw"
-		}
-	}
+		return fieldName
 }


### PR DESCRIPTION
The computer can now check the stats of it's card and choose one that will be difficult to beat. This logic gets triggered if `stat_to_compare` is `null`

- Added function `computerChooseCompetitiveStat`
- Added helper function `findLowestScore` which works within `computerChooseCompetitiveStat`
- Refactored logic by creating a seprate helper function for converting snake case to pascal case 
- Note `stat_to_compare` in the comparison struct (used to unmarshal JSON from frontend) is now a pointer to a string. This allows us to check if the value of `stat_to_compare` is `null`

