### PR TITLE
Fix teardown function for testing

### DIFF
--- a/api/src/tests/controllers/plant_controllers_test.go
+++ b/api/src/tests/controllers/plant_controllers_test.go
@@ -26,6 +26,13 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	// Make sure tables are clean before starting tests
+	err = models_test.TeardownTestDatabase()
+	if err != nil {
+		fmt.Println("Error cleaning test database before tests:", err)
+		os.Exit(1)
+	}
+
 	// 2) Run the tests
 	code := m.Run()
 

--- a/api/src/tests/models/setup.go
+++ b/api/src/tests/models/setup.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/jackmisner/botaniclash/src/models"
@@ -24,8 +25,29 @@ func SetupTestDatabase() error {
 	}
 	models.Database = db
 
+	// Get current database connection
+	sqlDB, err := models.Database.DB()
+	if err != nil {
+		return err
+	}
+
+	// Check connection
+	err = sqlDB.Ping()
+	if err != nil {
+		return err
+	}
+
 	// Run migrations
 	models.AutoMigrateModels()
+
+	// Verify that critical tables exist
+	tables := []string{"users", "plants", "game_stats", "plant_ownerships"}
+	for _, table := range tables {
+		if !models.Database.Migrator().HasTable(table) {
+			// If table doesn't exist, there's an issue with migration
+			return fmt.Errorf("table %s does not exist after migration", table)
+		}
+	}
 
 	return nil
 }
@@ -34,12 +56,29 @@ func TeardownTestDatabase() error {
 	var tableNames []string
 
 	// Query to get all table names in the current database (PostgreSQL syntax)
-	models.Database.Raw("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'").Scan(&tableNames)
+	models.Database.Raw("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'").Scan(&tableNames)
 
-	// Iterate over each table name and drop it
+	// Instead of dropping tables, truncate them to maintain schema
+	// Use a transaction to ensure all truncates are performed or none
+	tx := models.Database.Begin()
+
+	// Disable foreign key checks while truncating
+	tx.Exec("SET session_replication_role = 'replica';")
+
+	// Truncate all tables
 	for _, tableName := range tableNames {
-		models.Database.Exec("DROP TABLE IF EXISTS " + tableName + " CASCADE")
+		// Skip migration tables
+		if tableName == "schema_migrations" {
+			continue
+		}
+		if err := tx.Exec("TRUNCATE TABLE " + tableName + " CASCADE").Error; err != nil {
+			tx.Rollback()
+			return err
+		}
 	}
 
-	return nil
+	// Re-enable foreign key checks
+	tx.Exec("SET session_replication_role = 'origin';")
+
+	return tx.Commit().Error
 }

--- a/api/src/tests/models/user_model_test.go
+++ b/api/src/tests/models/user_model_test.go
@@ -19,6 +19,13 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	// Make sure tables are clean before starting tests
+	err = TeardownTestDatabase()
+	if err != nil {
+		fmt.Println("Error cleaning test database before tests:", err)
+		os.Exit(1)
+	}
+
 	// 2) Run the tests
 	code := m.Run()
 


### PR DESCRIPTION
- there was an issue where a test would pass on the first run, but fail thereafter
- updated TeardownTestDatabase to truncate tables instead of dropping them completely
- had to use transaction handling to do this (although I'm not sure this is the most elegant way of doing it, it works)